### PR TITLE
Correct usage of Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 Practice refactoring techniques in the Martin Fowler's Refactoring 2nd edition
 
 ## Set up project: 
+
+This project is dependent on the package manager [Yarn](https://yarnpkg.com/en/docs/install).
+
 In the root directory of your project, run the following commands:
 
 ``` sh
- yarn init
- yarn add --save-dev mocha chai babel-register babel-preset-es201
+ yarn
 ```
 
 ## Run tests:


### PR DESCRIPTION
Now that you've initialised yarn, and specified the dependencies (see package.json), people just need to run `yarn` to install them; they don't also need to specify what to install.